### PR TITLE
Adding toXYZ() and rotate() for polygons

### DIFF
--- a/cython_csg/_cython_csg.pyx
+++ b/cython_csg/_cython_csg.pyx
@@ -335,7 +335,8 @@ class Polygon(object):
                 vert.normal = newVector(vert.normal)
 
     def toXYZ(self):
-        return map(list, zip(*[(vert.pos.x, vert.pos.y, vert.pos.z) for vert in self.vertices]))
+        x, y, z =  map(list, zip(*[(vert.pos.x, vert.pos.y, vert.pos.z) for vert in self.vertices]))
+        return x, y, z
 
     def __repr__(self):
         return reduce(lambda x, y: x + y,

--- a/cython_csg/_cython_csg.pyx
+++ b/cython_csg/_cython_csg.pyx
@@ -305,6 +305,38 @@ class Polygon(object):
         map(lambda v: v.flip(), self.vertices)
         self.plane.flip()
 
+    def rotate(self, axis, angleDeg):
+        """
+        Rotate polygon. (copy from rotate geometry)
+           axis: axis of rotation (array of floats)
+           angleDeg: rotation angle in degrees
+        """
+        ax = Vector(axis[0], axis[1], axis[2]).unit()
+        cosAngle = math.cos(math.pi * angleDeg / 180.)
+        sinAngle = math.sin(math.pi * angleDeg / 180.)
+
+        def newVector(v):
+            vA = v.dot(ax)
+            vPerp = v.minus(ax.times(vA))
+            vPerpLen = vPerp.length()
+            if vPerpLen == 0:
+                # vector is parallel to axis, no need to rotate
+                return v
+            u1 = vPerp.unit()
+            u2 = u1.cross(ax)
+            vCosA = vPerpLen*cosAngle
+            vSinA = vPerpLen*sinAngle
+            return ax.times(vA).plus(u1.times(vCosA).plus(u2.times(vSinA)))
+
+        for vert in self.vertices:
+            vert.pos = newVector(vert.pos)
+            normal = vert.normal
+            if normal.length() > 0:
+                vert.normal = newVector(vert.normal)
+
+    def toXYZ(self):
+        return map(list, zip(*[(vert.pos.x, vert.pos.y, vert.pos.z) for vert in self.vertices]))
+
     def __repr__(self):
         return reduce(lambda x, y: x + y,
                       ['Polygon(['] + [repr(v) + ', ' \


### PR DESCRIPTION
#3 __Polygon rotation__
Simply copied the rotation function from the CSG class to work with a single polygon. This function is useful for triangulation of polygons. Most triangulation works in 2D, therefore it is sometimes necessary to random_rotate polygon if the polygon.plane is vertical.

__toXYZ__
There was not yet an option to retrieve coordinate values straight from the Polygon.